### PR TITLE
Unit Tests for the PlanetScale Integration

### DIFF
--- a/integrations/test_planetscale.py
+++ b/integrations/test_planetscale.py
@@ -1,0 +1,32 @@
+import unittest
+from integrations.base_test import BaseTest
+from utils.config import get_value_from_json_env_var, generate_random_db_name
+
+
+class TestPlanetScaleConnection(BaseTest):
+    """
+    Test class for testing the PlanetScale datasource using the MindsDB SQL API.
+    """
+
+    def test_execute_query(self):
+        """
+        Create a new PlanetScale Datasource.
+        """
+        try:
+            cursor = self.connection.cursor()
+            random_db_name = generate_random_db_name("planetscale_datasource")
+            planetscale_config = get_value_from_json_env_var("INTEGRATIONS_CONFIG", 'planetscale')
+            query = self.query_generator.create_database_query(
+                random_db_name,
+                "planet_scale",
+                planetscale_config
+            )
+            cursor.execute(query)
+            cursor.close()
+        except Exception as err:
+            cloud_temp = self.template.get_integration_template("PlanetScale", "clmqcnjoh110175brod4y64g93f")
+            self.incident.report_incident("cl8nll9f7106187olof1m17eg17", cloud_temp)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/config_example.json
+++ b/utils/config_example.json
@@ -182,6 +182,13 @@
         "auth_provider_x509_cert_url": "mocked_auth_provider_x509_cert_url",
         "client_x509_cert_url": "mocked_client_x509_cert_url"
       }
+    },
+    "planetscale": {
+      "host": "mocked_host",
+      "port": "mocked_port",
+      "database":  "mocked_database",
+      "user": "mocked_user",
+      "password":  "mocked_password"
     }
 }
   


### PR DESCRIPTION
Added unit tests for the PlanetScale handler. This primarily tests the creation of a new PlanetScale data source using the CREATE DATABASE statement.