### PR TITLE
Unit Tests for the Docker Hub Integration

### DIFF
--- a/integrations/applications/test_dockerhub.py
+++ b/integrations/applications/test_dockerhub.py
@@ -1,0 +1,32 @@
+import unittest
+from integrations.base_test import BaseTest
+from utils.config import generate_random_db_name, get_value_from_json_env_var
+
+
+class TestDockerHubConnection(BaseTest):
+    """
+    Test class for testing the Docker Hub datasource using the MindsDB SQL API.
+    """
+
+    def test_execute_query(self):
+        """
+        Create a new Docker Hub Datasource.
+        """
+        try:
+            cursor = self.connection.cursor()
+            random_db_name = generate_random_db_name("dockerhub_datasource")
+            dockerhub_config = get_value_from_json_env_var("INTEGRATIONS_CONFIG", 'dockerhub')
+            query = self.query_generator.create_database_query(
+                        random_db_name,
+                        "dockerhub",
+                        dockerhub_config
+                    )
+            cursor.execute(query)
+            cursor.close()
+        except Exception as err:
+            cloud_temp = self.template.get_integration_template("Docker Hub", "clnx9m44t2220biomtbyws863")
+            self.incident.report_incident("cl8nll9f7106187olof1m17eg17", cloud_temp)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/integrations/applications/test_dockerhub.py
+++ b/integrations/applications/test_dockerhub.py
@@ -24,7 +24,7 @@ class TestDockerHubConnection(BaseTest):
             cursor.execute(query)
             cursor.close()
         except Exception as err:
-            cloud_temp = self.template.get_integration_template("Docker Hub", "clnx9m44t2220biomtbyws863")
+            cloud_temp = self.template.get_integration_template("Docker Hub", "clo48noho15824bln910dtac95")
             self.incident.report_incident("cl8nll9f7106187olof1m17eg17", cloud_temp)
 
 

--- a/utils/config_example.json
+++ b/utils/config_example.json
@@ -221,6 +221,10 @@
     },
     "newsapi": {
       "api_key": "mocked_api_key"
+    },
+    "dockerhub": {
+      "username": "mocked_username",
+      "password": "mocked_password"
     }
 }
   


### PR DESCRIPTION
This PR adds unit tests for the Docker Hub handler. This primarily tests the creation of a new Docker Hub data source using the CREATE DATABASE statement.