### PR TITLE
CREATE DATABASE Unit Test for the PayPal Integration

### DIFF
--- a/integrations/applications/test_paypal.py
+++ b/integrations/applications/test_paypal.py
@@ -17,10 +17,10 @@ class TestPayPalConnection(BaseTest):
             random_db_name = generate_random_db_name("paypal_datasource")
             paypal_config = get_value_from_json_env_var("INTEGRATIONS_CONFIG", 'paypal')
             query = self.query_generator.create_database_query(
-                        random_db_name,
-                        "paypal",
-                        paypal_config
-                    )
+                random_db_name,
+                "paypal",
+                paypal_config
+            )
             cursor.execute(query)
             cursor.close()
         except Exception as err:

--- a/integrations/applications/test_paypal.py
+++ b/integrations/applications/test_paypal.py
@@ -1,0 +1,32 @@
+import unittest
+from integrations.base_test import BaseTest
+from utils.config import generate_random_db_name, get_value_from_json_env_var
+
+
+class TestPayPalConnection(BaseTest):
+    """
+    Test class for testing the PayPal datasource using the MindsDB SQL API.
+    """
+
+    def test_execute_query(self):
+        """
+        Create a new PayPal Datasource.
+        """
+        try:
+            cursor = self.connection.cursor()
+            random_db_name = generate_random_db_name("paypal_datasource")
+            paypal_config = get_value_from_json_env_var("INTEGRATIONS_CONFIG", 'paypal')
+            query = self.query_generator.create_database_query(
+                        random_db_name,
+                        "paypal",
+                        paypal_config
+                    )
+            cursor.execute(query)
+            cursor.close()
+        except Exception as err:
+            cloud_temp = self.template.get_integration_template("PayPal", "clo48noho15824bln910dtac95")
+            self.incident.report_incident("cl8nll9f7106187olof1m17eg17", cloud_temp)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/integrations/applications/test_paypal.py
+++ b/integrations/applications/test_paypal.py
@@ -24,7 +24,7 @@ class TestPayPalConnection(BaseTest):
             cursor.execute(query)
             cursor.close()
         except Exception as err:
-            cloud_temp = self.template.get_integration_template("PayPal", "clo48noho15824bln910dtac95")
+            cloud_temp = self.template.get_integration_template("PayPal", "clpqqhs51112000b3ohx5a6766t")
             self.incident.report_incident("cl8nll9f7106187olof1m17eg17", cloud_temp)
 
 

--- a/utils/config_example.json
+++ b/utils/config_example.json
@@ -240,6 +240,11 @@
     },
     "cohere": {
       "api_key": "mocked_api_key"
+    },
+    "paypal": {
+      "client_id": "mocked_client_id",
+      "client_secret": "mocked_client_secret",
+      "mode": "mocked_mode"
     }
 }
   


### PR DESCRIPTION
This PR adds unit tests for the PayPal handler. This primarily tests the creation of a new PayPal data source using the CREATE DATABASE statement.